### PR TITLE
Avoid using to-be-deprecated `mobile` import

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.9.0.beta8: fbbf3f74550df66d59ea7662bd7ca2b271973ea1

--- a/javascripts/discourse/initializers/initialize-for-doc-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-doc-preview.js
@@ -1,14 +1,14 @@
 import {withPluginApi} from "discourse/lib/plugin-api";
 import {iconHTML} from "discourse-common/lib/icon-library";
-import Mobile from "discourse/lib/mobile";
 
 const PREVIEW_HEIGHT = 500;
 
 export default {
   name: "doc-previews",
-  initialize() {
+  initialize(container) {
     withPluginApi("0.8.41", (api) => {
-      if (Mobile.mobileView) return;
+      const site = container.lookup("service:site");
+      if (site.mobileView) return;
 
       try {
         const previewModeSetting = settings.preview_mode;


### PR DESCRIPTION
Accessing `mobileView` through the `Site` service is preferred.